### PR TITLE
Fix: Correct exit code for --version flag

### DIFF
--- a/main.js
+++ b/main.js
@@ -27,7 +27,7 @@ async function main() {
   // Check if the command-line argument is '--version' or '--v'.
   if (argument === "--version" || argument === "--v") {
     console.log(`> ${package.version}`); // Print the package version.
-    process.exit(1); // Exit with an error code.
+    process.exit(0); // Exit with success.
   }
 
   // Extract the base URL from the command-line argument, assuming it's a valid URL.


### PR DESCRIPTION
## Bug Description

The `--version` flag was exiting with error code 1, which incorrectly indicates an error occurred when the version was successfully displayed.

## Fix

Changed `process.exit(1)` to `process.exit(0)` on line 30 to follow standard Unix conventions:
- Exit code 0 = success
- Exit code 1 = error

## Testing

```bash
$ node main.js --version
> 1.0.0
$ echo $?
0
```

Previously, the exit code was 1, now it correctly returns 0.

---

*This PR was generated by [PRJanitor](https://prjanitor.com) — an automated tool that finds and fixes small bugs in open-source projects.*

We respect your contribution guidelines — if your project doesn't accept bot PRs, we won't send more. You can also add a `.github/prjanitor.yml` file with `enabled: false` to opt out explicitly.